### PR TITLE
oniontracetools: search the relative search path, not just the filename

### DIFF
--- a/tools/oniontracetools/oniontracetools
+++ b/tools/oniontracetools/oniontracetools
@@ -126,7 +126,7 @@ to use the number of available processor cores""",
     analyze_parser.add_argument('-e', '--expression',
         help="""Append a regex PATTERN to a custom list of strings used with
 re.search to find log file names in the search path. The custom list of patterns
-will override the default pattern 'oniontrace.*\.log'.""",
+will override the default pattern 'oniontrace[^/]*\.log$'.""",
         metavar="PATTERN", type=str,
         action="append", dest="patterns",
         default=[])
@@ -175,7 +175,7 @@ By default, results from all hosts in the analysis file will get plotted.""",
 def analyze(args):
     from oniontracetools.analysis import ParallelAnalysis, SerialAnalysis
 
-    searchexp = args.patterns if len(args.patterns) > 0 else ["oniontrace.*\.log"]
+    searchexp = args.patterns if len(args.patterns) > 0 else ["oniontrace[^/]*\.log$"]
 
     paths = []
     if os.path.isdir(args.log_file_path):

--- a/tools/oniontracetools/util.py
+++ b/tools/oniontracetools/util.py
@@ -29,9 +29,10 @@ def find_file_paths(searchpath, patterns):
             for name in files:
                 found = False
                 fpath = os.path.join(root, name)
-                fbase = os.path.basename(fpath)
+                # search only the relative path + filename (relative to the original search path)
+                frelpath = os.path.relpath(fpath, searchpath)
                 for pattern in patterns:
-                    if re.search(pattern, fbase): found = True
+                    if re.search(pattern, frelpath): found = True
                 if found: paths.append(fpath)
     return paths
 


### PR DESCRIPTION
We need this for tornettools to work with Shadow 3.x simulations.

See: shadow/tornettools#97